### PR TITLE
removes array_map warning in line 147 if network_sites array is empty…

### DIFF
--- a/wp-multisite-sso.php
+++ b/wp-multisite-sso.php
@@ -112,6 +112,8 @@ class WP_MultiSite_SSO {
 
 		$current_blog_id = get_current_blog_id();
 
+		$sso_objects = array();
+
 		// IP address.
 		$ip_address = '';
 		if ( !empty( $_SERVER['REMOTE_ADDR'] ) ) {


### PR DESCRIPTION
… (single site). $sso_object must be an array even if the foreach loop in line 131 is passed without any loop.