### PR TITLE
Introduce filter, 'wp_multisite_sso_pre_get_network_sites'

### DIFF
--- a/wp-multisite-sso.php
+++ b/wp-multisite-sso.php
@@ -53,6 +53,23 @@ class WP_MultiSite_SSO {
 	public static function get_network_sites( $network_sites = array() ) {
 		$network_sites = array();
 
+		/**
+		 * Filters the list of network sites for SSO before it is populated.
+		 *
+		 * Passing a non-null value to the filter will effectively short circuit
+		 * this method, returning that value instead.
+		 *
+		 * @since 1.x
+		 *
+		 * @param null $retval Return array with the blog ID as array key and domain URL as array value.
+		 */
+		$pre_get_sites = apply_filters( 'wp_multisite_sso_pre_get_network_sites', null );
+
+		// Allow developers to bail out of default network site lookup.
+		if ( null !== $pre_get_sites ) {
+			return $pre_get_sites;
+		}
+
 		// get list of sites
 		$sites = function_exists('get_sites') ? get_sites() : wp_get_sites();
 


### PR DESCRIPTION
Thanks for the useful plugin!

In the `get_network_sites()` method, by default, it fetches all sites and active mapped domains.

For our site's needs, we don't need to fetch all sites since most of our sites are subdomains, so logging in from the main site handles 90% of our needs here.  Related: #26.

Secondly, we have many mapped domains, so the default behavior to login to each mapped domain isn't useful to us.  Also, not all mapped domains are `active` or in WPMU Domain Mapping terms, `primary`.

In this PR, I've introduced a new filter, `'wp_multisite_sso_pre_get_network_sites'`, to allow developers to do their own site lookup routine to bypass the default network site lookup.

If you're interested to see how we're using this filter, let me know and I can pass on what we're using.  We basically are using this filter to address #6.