### PR TITLE
Fix url scheme mismatch in SSO login and out

### DIFF
--- a/wp-multisite-sso.php
+++ b/wp-multisite-sso.php
@@ -62,7 +62,7 @@ class WP_MultiSite_SSO {
 			if ( !isset( $site['blog_id'] ) || !isset( $site['domain'] ) )
 				continue;
 
-			$network_sites[$site['blog_id']] = esc_url( $site['domain'] );
+			$network_sites[$site['blog_id']] = set_url_scheme( esc_url( $site['domain'] ), 'login' );
 		}
 
 		// if domain mapping exists, attempt to map the sites to the mapped domain
@@ -72,7 +72,7 @@ class WP_MultiSite_SSO {
 			if ( !isset( $mapped_domain->domain ) || !isset( $mapped_domain->blog_id ) )
 				continue;
 
-			$network_sites[$mapped_domain->blog_id] = esc_url( $mapped_domain->domain );
+			$network_sites[$mapped_domain->blog_id] = set_url_scheme( esc_url( $mapped_domain->domain ), 'login' );
 		}
 
 		return $network_sites;


### PR DESCRIPTION
When the login page on a network site is https, the SSO script will be blocked because of protocol mismatch when it tries to load each site over the http url which is generated by `esc_url( $site['domain'] )`.

This fixes that issue by setting the URL scheme to the same as the current site's login scheme (which should really be https on any modern sites).

Fixes #7. (Other approaches exist in #15 and #16, but I think this is a simpler and more generally applicable approach.)