### PR TITLE
Prevent duplicate inserts into domain mapping logins table

### DIFF
--- a/wp-multisite-sso.php
+++ b/wp-multisite-sso.php
@@ -72,7 +72,17 @@ class WP_MultiSite_SSO {
 			if ( !isset( $mapped_domain->domain ) || !isset( $mapped_domain->blog_id ) )
 				continue;
 
-			$network_sites[$mapped_domain->blog_id] = set_url_scheme( esc_url( $mapped_domain->domain ), 'login' );
+			$mapped_domain_login_host = set_url_scheme(
+				esc_url( $mapped_domain->domain ),
+				'login'
+			);
+
+			// Don't log into a mapped domain if its already in the list of network sites.
+			// (The same domain can appear as two different blogs, if one of
+			// them redirects as an "alias" of another.)
+			if ( ! in_array( $mapped_domain_login_host, $network_sites, true ) ) {
+				$network_sites[$mapped_domain->blog_id] = $mapped_domain_login_host;
+			}
 		}
 
 		return $network_sites;


### PR DESCRIPTION
When using this plugin along with the WP MU Domain Mapping plugin, it's possible for the same domain to be returned twice in the response for WP_Multisite_SSO::get_network_sites() if a domain is used as an alias of another blog.

This commit removes duplicate domains from the return value here, so that we don't try to log into the same domain twice. (Logging into the same domain twice causes issues duplicate insert issues, because the blog ID of a domain is used along with the current timestamp to build the insert key in the wp_domain_mapping_logins table.)